### PR TITLE
Prefetch options for etcd and Consul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - export PATH="$GOPATH/bin:$PATH"
   - docker run -d -p 2379:2379 quay.io/coreos/etcd /usr/local/bin/etcd -advertise-client-urls http://0.0.0.0:2379 -listen-client-urls http://0.0.0.0:2379
   - docker run -d -p 8500:8500 --name consul consul
-  - docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault
+  - docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault:0.9.6
 
 env:
   - VAULT_ADDR=http://127.0.0.1:8200

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,6 +21,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/fatih/structs"
+  packages = ["."]
+  revision = "a720dfa8df582c51dee1b36feabb906bde1588bd"
+  version = "v1.0"
+
+[[projects]]
   name = "github.com/go-yaml/yaml"
   packages = ["."]
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
@@ -115,8 +121,8 @@
     "helper/parseutil",
     "helper/strutil"
   ]
-  revision = "5dd7f25f5c4b541f2da62d70075b6f82771a650d"
-  version = "v0.10.0"
+  revision = "7e1fbde40afee241f81ef08700e7987d86fc7242"
+  version = "v0.9.6"
 
 [[projects]]
   branch = "master"
@@ -239,6 +245,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "13251d2c404176de8233a34608178a7b88980eefdc18f7b2872fab7b82de93de"
+  inputs-digest = "dd119391aa68184558f6ef082ab5f3155d9b87ec9e987c896a34bb9dcabe1bc0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,8 +11,8 @@
     "mvcc/mvccpb",
     "pkg/types"
   ]
-  revision = "c9d46ab3799b7f2174268e75f72d01e6d6aac953"
-  version = "v3.3.2"
+  revision = "e348b1aedd9167360c466ae98f7343d3e22281f8"
+  version = "v3.3.3"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -21,16 +21,10 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/fatih/structs"
-  packages = ["."]
-  revision = "a720dfa8df582c51dee1b36feabb906bde1588bd"
-  version = "v1.0"
-
-[[projects]]
   name = "github.com/go-yaml/yaml"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -63,8 +57,8 @@
 [[projects]]
   name = "github.com/hashicorp/consul"
   packages = ["api"]
-  revision = "9a494b5fb9c86180a5702e29c485df1507a47198"
-  version = "v1.0.6"
+  revision = "fb848fc48818f58690db09d14640513aa6bf3c02"
+  version = "v1.0.7"
 
 [[projects]]
   branch = "master"
@@ -104,7 +98,7 @@
     "json/scanner",
     "json/token"
   ]
-  revision = "f40e974e75af4e271d97ce0fc917af5898ae7bda"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/hashicorp/serf"
@@ -121,8 +115,8 @@
     "helper/parseutil",
     "helper/strutil"
   ]
-  revision = "7e1fbde40afee241f81ef08700e7987d86fc7242"
-  version = "v0.9.6"
+  revision = "5dd7f25f5c4b541f2da62d70075b6f82771a650d"
+  version = "v0.10.0"
 
 [[projects]]
   branch = "master"
@@ -174,6 +168,7 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
@@ -181,7 +176,7 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
+  revision = "d41e8174641f662c5a2d1c7a5f9e828788eb8706"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -208,7 +203,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "f8c8703595236ae70fdf8789ecb656ea0bcdcf46"
+  revision = "7fd901a49ba6a7f87732eb344f6e3c5b19d1b200"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -238,12 +233,12 @@
     "tap",
     "transport"
   ]
-  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
-  version = "v1.10.0"
+  revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
+  version = "v1.11.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d7e2815c5a5540ba66d586045277848589a2145bb8ada25465a1d217d2f43a85"
+  inputs-digest = "13251d2c404176de8233a34608178a7b88980eefdc18f7b2872fab7b82de93de"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "0.10.0"
+  version = "0.9.0"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "0.9.3"
+  version = "0.10.0"
 
 [prune]
   go-tests = true

--- a/backend/consul/consul.go
+++ b/backend/consul/consul.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"context"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/heetch/confita/backend"
@@ -10,20 +11,38 @@ import (
 
 // Backend loads keys from Consul.
 type Backend struct {
-	client *api.Client
-	prefix string
+	client   *api.Client
+	prefix   string
+	prefetch bool
+	cache    map[string][]byte
 }
 
 // NewBackend creates a configuration loader that loads from Consul.
-func NewBackend(client *api.Client, prefix string) *Backend {
-	return &Backend{
+func NewBackend(client *api.Client, opts ...Option) *Backend {
+	b := Backend{
 		client: client,
-		prefix: prefix,
 	}
+
+	for _, opt := range opts {
+		opt(&b)
+	}
+
+	return &b
 }
 
 // Get loads the given key from Consul.
 func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
+	if b.cache == nil && b.prefetch {
+		err := b.fetchTree(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if b.cache != nil {
+		return b.fromCache(ctx, key)
+	}
+
 	var opt api.QueryOptions
 
 	kv, _, err := b.client.KV().Get(path.Join(b.prefix, key), opt.WithContext(ctx))
@@ -38,7 +57,52 @@ func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
 	return kv.Value, nil
 }
 
+func (b *Backend) fetchTree(ctx context.Context) error {
+	var opt api.QueryOptions
+
+	list, _, err := b.client.KV().List(b.prefix, opt.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	b.cache = make(map[string][]byte)
+
+	for _, kv := range list {
+		b.cache[strings.TrimLeft(kv.Key, b.prefix+"/")] = kv.Value
+	}
+
+	return nil
+}
+
+func (b *Backend) fromCache(ctx context.Context, key string) ([]byte, error) {
+	v, ok := b.cache[key]
+	if !ok {
+		return nil, backend.ErrNotFound
+	}
+
+	return v, nil
+}
+
 // Name returns the name of the backend.
 func (b *Backend) Name() string {
 	return "consul"
+}
+
+// Option is used to configure the Consul backend.
+type Option func(*Backend)
+
+// WithPrefix is used to specify the prefix to prepend on every keys.
+func WithPrefix(prefix string) Option {
+	return func(b *Backend) {
+		b.prefix = prefix
+	}
+}
+
+// WithPrefetch is used to prefetch the entire tree and cache it to
+// avoid further round trips. If the WithPrefix option is used, will fetch
+// the tree under the specified prefix.
+func WithPrefetch() Option {
+	return func(b *Backend) {
+		b.prefetch = true
+	}
 }

--- a/backend/consul/consul_test.go
+++ b/backend/consul/consul_test.go
@@ -16,7 +16,7 @@ func TestConsulBackend(t *testing.T) {
 	require.NoError(t, err)
 	defer client.KV().DeleteTree(prefix, nil)
 
-	b := NewBackend(client, prefix)
+	b := NewBackend(client, WithPrefix(prefix))
 
 	t.Run("NotFound", func(t *testing.T) {
 		_, err = b.Get(context.Background(), "something that doesn't exist")
@@ -41,4 +41,46 @@ func TestConsulBackend(t *testing.T) {
 		_, err = b.Get(ctx, "key2")
 		require.Error(t, err)
 	})
+}
+
+func TestConsulBackendWithPrefetch(t *testing.T) {
+	prefix := "confita-tests"
+
+	client, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+	defer client.KV().DeleteTree(prefix, nil)
+
+	b := NewBackend(client, WithPrefix(prefix), WithPrefetch())
+
+	t.Run("OK", func(t *testing.T) {
+		_, err = client.KV().Put(&api.KVPair{Key: prefix + "/key1", Value: []byte("value1")}, nil)
+		require.NoError(t, err)
+
+		_, err = client.KV().Put(&api.KVPair{Key: prefix + "/key2", Value: []byte("value2")}, nil)
+		require.NoError(t, err)
+
+		_, err = client.KV().Put(&api.KVPair{Key: prefix + "/key3", Value: []byte("value3")}, nil)
+		require.NoError(t, err)
+
+		val, err := b.Get(context.Background(), "key1")
+		require.NoError(t, err)
+
+		// deleting the tree
+		client.KV().DeleteTree(prefix, nil)
+
+		// WithPrefetch should have prefetched all the keys
+		// they should be available even if the tree has been removed.
+		val, err = b.Get(context.Background(), "key1")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value1"), val)
+
+		val, err = b.Get(context.Background(), "key2")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value2"), val)
+
+		val, err = b.Get(context.Background(), "key3")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value3"), val)
+	})
+
 }

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -16,7 +16,55 @@ func TestEtcdBackend(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	b := NewBackend(client, "prefix")
+	b := NewBackend(client, WithPrefix("prefix"))
 	_, err = b.Get(context.Background(), "something that doesn't exist")
 	require.Equal(t, backend.ErrNotFound, err)
+}
+
+func TestEtcdBackendWithPrefetch(t *testing.T) {
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{"localhost:2379"},
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	prefix := "confita-tests"
+
+	ctx := context.Background()
+
+	defer client.KV.Delete(ctx, prefix, clientv3.WithPrefix())
+
+	b := NewBackend(client, WithPrefix(prefix), WithPrefetch())
+
+	t.Run("OK", func(t *testing.T) {
+		_, err = client.KV.Put(ctx, prefix+"/key1", "value1")
+		require.NoError(t, err)
+
+		_, err = client.KV.Put(ctx, prefix+"/key2", "value2")
+		require.NoError(t, err)
+
+		_, err = client.KV.Put(ctx, prefix+"/key3", "value3")
+		require.NoError(t, err)
+
+		val, err := b.Get(ctx, "key1")
+		require.NoError(t, err)
+
+		// deleting the tree
+		client.KV.Delete(ctx, prefix, clientv3.WithPrefix())
+
+		// WithPrefetch should have prefetched all the keys
+		// they should be available even if the tree has been removed.
+		val, err = b.Get(ctx, "key1")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value1"), val)
+
+		val, err = b.Get(ctx, "key2")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value2"), val)
+
+		val, err = b.Get(ctx, "key3")
+		require.NoError(t, err)
+		require.Equal(t, []byte("value3"), val)
+	})
+
 }

--- a/backend/vault/vault_test.go
+++ b/backend/vault/vault_test.go
@@ -21,6 +21,8 @@ func TestVaultBackend(t *testing.T) {
 
 	path := "secret/test"
 
+	defer c.Delete(path)
+
 	t.Run("SecretPathNotFound", func(t *testing.T) {
 		b := NewBackend(c, path)
 		_, err := b.Get(context.Background(), "foo")

--- a/backend/vault/vault_test.go
+++ b/backend/vault/vault_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/vault/api"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestVaultBackend(t *testing.T) {
+	os.Setenv("VAULT_ADDR", "http://127.0.0.1:8200")
 	client, err := api.NewClient(api.DefaultConfig())
 	require.NoError(t, err)
 
@@ -18,14 +20,16 @@ func TestVaultBackend(t *testing.T) {
 	c := client.Logical()
 
 	path := "secret/test"
-	b := NewBackend(c, path)
 
 	t.Run("SecretPathNotFound", func(t *testing.T) {
+		b := NewBackend(c, path)
 		_, err := b.Get(context.Background(), "foo")
 		require.EqualError(t, err, "secret not found at the following path: secret/test")
 	})
 
 	t.Run("OK", func(t *testing.T) {
+		b := NewBackend(c, path)
+
 		_, err = c.Write(path,
 			map[string]interface{}{
 				"foo":    "bar",
@@ -43,6 +47,7 @@ func TestVaultBackend(t *testing.T) {
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
+		b := NewBackend(c, path)
 		_, err := b.Get(context.Background(), "badKey")
 		require.EqualError(t, err, backend.ErrNotFound.Error())
 	})


### PR DESCRIPTION
This PR adds a prefetch option for etcd and Consul that makes them fetch the entire subtree, cache it and use the cache to serve the keys to Confita without additional network round trips.
Fixes #10 