### PR TITLE
Flags backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,16 @@ type Config struct {
 
 ### Command line flags
 
-The `flags` backend allows to load individual configuration keys from the environment. The default values are extracted from the struct fields values.
+The `flags` backend allows to load individual configuration keys from the command line. The default values are extracted from the struct fields values.
 
 ```sh
 ./bin -h
 
 Usage of ./bin:
   -host string
-       (default "http://some-host")
+       (default "127.0.0.1")
   -port int
-       (default "hello")
+       (default 5656)
   -timeout duration
        (default 10s)
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Confita is a library that loads configuration from multiple backends and stores 
 - Environment variables
 - JSON files
 - Yaml files
+- Command line flags
 - [etcd](https://github.com/coreos/etcd)
 - [Consul](https://www.consul.io/)
 - [Vault](https://www.vaultproject.io/)
@@ -87,6 +88,7 @@ loader := confita.NewLoader(
   env.NewBackend(),
   file.NewBackend("/path/to/config.json"),
   file.NewBackend("/path/to/config.yaml"),
+  flags.NewBackend(),
   etcd.NewBackend(etcdClientv3),
   consul.NewBackend(consulClient),
   vault.NewBackend(vaultClient),
@@ -141,6 +143,22 @@ type Config struct {
   Port        uint32        `config:"port,required,backend=etcd"`
   Timeout     time.Duration `config:"timeout"`
 }
+```
+
+### Command line flags
+
+The `flags` backend allows to load individual configuration keys from the environment. The default values are extracted from the struct fields values.
+
+```sh
+./bin -h
+
+Usage of ./bin:
+  -host string
+       (default "http://some-host")
+  -port int
+       (default "hello")
+  -timeout duration
+       (default 10s)
 ```
 
 ## License

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -34,7 +34,6 @@ func (b *backendFunc) Name() string {
 	return b.name
 }
 
-// A ValueUnmarshaler decodes a value identified by a key into a target.
-type ValueUnmarshaler interface {
-	UnmarshalValue(ctx context.Context, key string, to interface{}) error
+type Unmarshaler interface {
+	Unmarshal(ctx context.Context, to interface{}) error
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -33,7 +33,3 @@ func (b *backendFunc) Get(ctx context.Context, key string) ([]byte, error) {
 func (b *backendFunc) Name() string {
 	return b.name
 }
-
-type Unmarshaler interface {
-	Unmarshal(ctx context.Context, to interface{}) error
-}

--- a/backend/flags/flags.go
+++ b/backend/flags/flags.go
@@ -3,6 +3,8 @@ package flags
 import (
 	"context"
 	"flag"
+	"reflect"
+	"time"
 
 	"github.com/heetch/confita"
 	"github.com/pkg/errors"
@@ -16,14 +18,41 @@ func NewBackend() *Backend {
 	return new(Backend)
 }
 
-// LoadStruct takes a struct config, define flags based on it and parse the command line args,
+// LoadStruct takes a struct config, define flags based on it and parse the command line args.
 func (b *Backend) LoadStruct(ctx context.Context, cfg *confita.StructConfig) error {
-	for _, f := range cfg.Fields {
-		if f.Backend != "" {
+	for _, field := range cfg.Fields {
+		f := field
+
+		if f.Backend != "" && f.Backend != b.Name() {
 			continue
 		}
 
-		flag.Var(&flagValue{f}, f.Key, "")
+		k := f.Value.Kind()
+		switch {
+		case f.Value.Type().String() == "time.Duration":
+			flag.DurationVar(f.Value.Addr().Interface().(*time.Duration), f.Key, time.Duration(f.Value.Int()), "")
+		case k == reflect.Bool:
+			flag.BoolVar(f.Value.Addr().Interface().(*bool), f.Key, f.Value.Bool(), "")
+		case k >= reflect.Int && k <= reflect.Int64:
+			v := flag.Int(f.Key, int(f.Value.Int()), "")
+			defer func() {
+				f.Value.SetInt(int64(*v))
+			}()
+		case k >= reflect.Uint && k <= reflect.Uint64:
+			v := flag.Uint(f.Key, uint(f.Value.Uint()), "")
+			defer func() {
+				f.Value.SetUint(uint64(*v))
+			}()
+		case k >= reflect.Float32 && k <= reflect.Float64:
+			v := flag.Float64(f.Key, f.Value.Float(), "")
+			defer func() {
+				f.Value.SetFloat(*v)
+			}()
+		case k == reflect.String:
+			flag.StringVar(f.Value.Addr().Interface().(*string), f.Key, f.Value.String(), "")
+		default:
+			flag.Var(&flagValue{f}, f.Key, "")
+		}
 	}
 
 	flag.Parse()
@@ -36,6 +65,10 @@ type flagValue struct {
 }
 
 func (f *flagValue) String() string {
+	if f.FieldConfig == nil {
+		return ""
+	}
+
 	return f.Key
 }
 

--- a/backend/flags/flags.go
+++ b/backend/flags/flags.go
@@ -1,0 +1,50 @@
+package flags
+
+import (
+	"context"
+	"flag"
+
+	"github.com/heetch/confita"
+	"github.com/pkg/errors"
+)
+
+// Backend that loads configuration from the command line flags.
+type Backend struct{}
+
+// NewBackend creates a flags backend.
+func NewBackend() *Backend {
+	return new(Backend)
+}
+
+// LoadStruct takes a struct config, define flags based on it and parse the command line args,
+func (b *Backend) LoadStruct(ctx context.Context, cfg *confita.StructConfig) error {
+	for _, f := range cfg.Fields {
+		if f.Backend != "" {
+			continue
+		}
+
+		flag.Var(&flagValue{f}, f.Key, "")
+	}
+
+	flag.Parse()
+
+	return nil
+}
+
+type flagValue struct {
+	*confita.FieldConfig
+}
+
+func (f *flagValue) String() string {
+	return f.Key
+}
+
+// Get is not implemented.
+func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Name returns the type of the file.
+func (b *Backend) Name() string {
+	return "flags"
+}

--- a/backend/flags/flags_test.go
+++ b/backend/flags/flags_test.go
@@ -1,0 +1,28 @@
+package flags
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/heetch/confita"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlags(t *testing.T) {
+	var a int
+
+	r := reflect.Indirect(reflect.ValueOf(&a))
+
+	s := confita.StructConfig{Fields: []*confita.FieldConfig{
+		&confita.FieldConfig{Key: "some-int", Value: &r},
+	}}
+
+	os.Args = append(os.Args, "-some-int", "10")
+
+	b := new(Backend)
+	err := b.LoadStruct(context.Background(), &s)
+	require.NoError(t, err)
+	require.Equal(t, 10, a)
+}

--- a/backend/flags/flags_test.go
+++ b/backend/flags/flags_test.go
@@ -1,28 +1,99 @@
 package flags
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
-	"reflect"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/heetch/confita"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFlags(t *testing.T) {
-	var a int
+type Config struct {
+	A    string        `config:"a"`
+	Adef string        `config:"a-def"`
+	B    bool          `config:"b"`
+	Bdef bool          `config:"b-def"`
+	C    time.Duration `config:"c"`
+	Cdef time.Duration `config:"c-def"`
+	D    int           `config:"d"`
+	Ddef int           `config:"d-def"`
+}
 
-	r := reflect.Indirect(reflect.ValueOf(&a))
+func runHelper(t *testing.T, args ...string) *Config {
+	t.Helper()
 
-	s := confita.StructConfig{Fields: []*confita.FieldConfig{
-		&confita.FieldConfig{Key: "some-int", Value: &r},
-	}}
+	var output bytes.Buffer
 
-	os.Args = append(os.Args, "-some-int", "10")
-
-	b := new(Backend)
-	err := b.LoadStruct(context.Background(), &s)
+	cs := []string{"-test.run=TestHelperProcess", "--"}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Stderr = &output
+	cmd.Env = []string{"GO_HELPER_PROCESS=1"}
+	err := cmd.Run()
 	require.NoError(t, err)
-	require.Equal(t, 10, a)
+
+	var cfg Config
+
+	err = json.NewDecoder(&output).Decode(&cfg)
+	require.NoError(t, err)
+
+	return &cfg
+}
+
+func TestFlags(t *testing.T) {
+	t.Run("Use defaults", func(t *testing.T) {
+		cfg := runHelper(t, "-a=hello", "-b=true", "-c=10s", "-d=-100")
+		require.Equal(t, "hello", cfg.A)
+		require.Equal(t, true, cfg.B)
+		require.Equal(t, 10*time.Second, cfg.C)
+		require.Equal(t, -100, cfg.D)
+	})
+
+	t.Run("Override defaults", func(t *testing.T) {
+		cfg := runHelper(t, "-a-def=bye", "-b-def=false", "-c-def=15s", "-d-def=-200")
+		require.Equal(t, "bye", cfg.Adef)
+		require.Equal(t, false, cfg.Bdef)
+		require.Equal(t, 15*time.Second, cfg.Cdef)
+		require.Equal(t, -200, cfg.Ddef)
+	})
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No args\n")
+		os.Exit(2)
+	}
+
+	os.Args = append(os.Args[:1], args...)
+
+	cfg := Config{
+		Adef: "hello",
+		Bdef: true,
+		Cdef: 10 * time.Second,
+		Ddef: -100,
+	}
+
+	err := confita.NewLoader(NewBackend()).Load(context.Background(), &cfg)
+	require.NoError(t, err)
+	err = json.NewEncoder(os.Stderr).Encode(&cfg)
+	require.NoError(t, err)
+	os.Exit(0)
 }

--- a/config.go
+++ b/config.go
@@ -108,6 +108,11 @@ func (l *Loader) parseStruct(ref *reflect.Value) *StructConfig {
 			Value: &value,
 		}
 
+		// copying field content to a new value
+		clone := reflect.Indirect(reflect.New(f.Value.Type()))
+		clone.Set(*f.Value)
+		f.Default = &clone
+
 		if idx := strings.Index(tag, ","); idx != -1 {
 			f.Key = tag[:idx]
 			opts := strings.Split(tag[idx+1:], ",")
@@ -212,6 +217,7 @@ type FieldConfig struct {
 	Name     string
 	Key      string
 	Value    *reflect.Value
+	Default  *reflect.Value
 	Required bool
 	Backend  string
 }


### PR DESCRIPTION
This PR adds the support of the flags backend.
A new interface has been added `StructLoader` which is used to indicate that the backend wants to use the **parsed** struct informations directly and manipulate it.
The `ValueUnmarshaler` struct has been removed and replaced by a simpler `Unmarshaler` interface that can be used directly by json and yaml.

Fixes #20 