### PR TITLE
Upgrade to dep v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor/
-glide.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - docker run -d -p 8500:8500 --name consul consul
   - docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault:0.9.6
 
-install: dep ensure
+install: dep ensure -v -vendor-only
 
 script:
   - go test -v -race -cover -timeout=1m ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,24 @@ language: go
 services:
   - docker
 
+go:
+  - 1.9.x
+  - 1.10.x
+  - tip
+
+env:
+  - VAULT_ADDR=http://127.0.0.1:8200
+
 before_install:
   - mkdir -p $GOPATH/bin
-  - wget -O $GOPATH/bin/dep "https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64"
+  - wget -O $GOPATH/bin/dep "https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64"
   - chmod +x $GOPATH/bin/dep
   - export PATH="$GOPATH/bin:$PATH"
   - docker run -d -p 2379:2379 quay.io/coreos/etcd /usr/local/bin/etcd -advertise-client-urls http://0.0.0.0:2379 -listen-client-urls http://0.0.0.0:2379
   - docker run -d -p 8500:8500 --name consul consul
   - docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault:0.9.6
 
-env:
-  - VAULT_ADDR=http://127.0.0.1:8200
-
-
 install: dep ensure
-
-go:
-  - 1.9
-  - "1.10"
-  - tip
 
 script:
   - go test -v -race -cover -timeout=1m ./...


### PR DESCRIPTION
Hey folks! Around 2 weeks ago a new version of go dep has been released https://github.com/golang/dep/releases/tag/v0.5.0. Let's use it :)