### PR TITLE
Tiny little fix for vault backend

### DIFF
--- a/backend/file/file_test.go
+++ b/backend/file/file_test.go
@@ -39,15 +39,18 @@ func TestFileBackend(t *testing.T) {
 		Timeout time.Duration
 	}
 
-	testLoad := func(t *testing.T, path string) {
-		var c config
+	ekv := config{
+		Name:    "some name",
+		Age:     10,
+		Timeout: 10,
+	}
+
+	testLoad := func(t *testing.T, path string, template interface{}, expected interface{}) {
 		b := file.NewBackend(path)
 
-		err := b.Unmarshal(context.Background(), &c)
+		err := b.Unmarshal(context.Background(), template)
 		require.NoError(t, err)
-		require.Equal(t, "some name", c.Name)
-		require.Equal(t, 10, c.Age)
-		require.Equal(t, 10*time.Nanosecond, c.Timeout)
+		require.EqualValues(t, expected, template)
 	}
 
 	t.Run("JSON", func(t *testing.T) {
@@ -58,7 +61,7 @@ func TestFileBackend(t *testing.T) {
 		}`)
 		defer cleanup()
 
-		testLoad(t, path)
+		testLoad(t, path, &config{}, &ekv)
 	})
 
 	t.Run("YAML", func(t *testing.T) {
@@ -69,18 +72,66 @@ func TestFileBackend(t *testing.T) {
 `)
 		defer cleanup()
 
-		testLoad(t, path)
+		testLoad(t, path, &config{}, &ekv)
 	})
-
 	t.Run("TOML", func(t *testing.T) {
-		path, cleanup := createTempFile(t, "config.toml",
-			`name = "some name"
+
+		t.Run("Simple KV", func(t *testing.T) {
+			path, cleanup := createTempFile(t, "config.toml",
+				`name = "some name"
 age = 10
 timeout = 10
 `)
-		defer cleanup()
+			defer cleanup()
 
-		testLoad(t, path)
+			testLoad(t, path, &config{}, &ekv)
+		})
+
+		t.Run("TOML Table", func(t *testing.T) {
+			path, cleanup := createTempFile(t, "config.toml",
+				`title = "title!"
+[Config]
+name = "some name"
+age = 10
+timeout = 10
+`)
+			defer cleanup()
+			type Config struct {
+				Title  string
+				Config config
+			}
+			e := Config{
+				Title: "title!",
+				Config: config{
+					Name:    "some name",
+					Age:     10,
+					Timeout: 10,
+				},
+			}
+
+			testLoad(t, path, &Config{}, &e)
+		})
+
+		t.Run("TOML Array of Tables", func(t *testing.T) {
+			path, cleanup := createTempFile(t, "config.toml",
+				`[[Config]]
+name = "Alice"
+age = 10
+timeout = 10
+[[Config]]
+name = "Bob"
+age = 11
+timeout = 11
+`)
+			defer cleanup()
+			type Configs struct {
+				Config []config
+			}
+			e := Configs{Config: []config{{Name: "Alice", Age: 10, Timeout: 10}, {Name: "Bob", Age: 11, Timeout: 11}}}
+
+			testLoad(t, path, &Configs{}, &e)
+		})
+
 	})
 
 	t.Run("Unsupported extension", func(t *testing.T) {

--- a/backend/vault/vault.go
+++ b/backend/vault/vault.go
@@ -45,3 +45,6 @@ func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
 
 	return nil, backend.ErrNotFound
 }
+func (b *Backend) Name() string {
+	return "vault"
+}


### PR DESCRIPTION
vault Backend type doesn't implement backend.Backend because of missing Name method. It's little fix for that