### PR TITLE
Map backend #12 - added a map to store default in backend

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -21,7 +21,7 @@ func Func(name string, fn func(context.Context, string) ([]byte, error)) Backend
 	return &backendFunc{fn: fn, name: name}
 }
 
-// Func creates a Backend from a function and allows users to add a defai;t map.
+// FuncWithDefaults creates a Backend from a function and allows users to add a default map.
 func FuncWithDefaults(name string, defaults map[string]string, fn func(context.Context, string) ([]byte, error)) Backend {
 	return &backendFunc{fn: fn, name: name, defaults: defaults}
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,7 @@ var (
 type Backend interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Name() string
+	Defaults() map[string]string
 }
 
 // Func creates a Backend from a function.
@@ -21,9 +22,15 @@ func Func(name string, fn func(context.Context, string) ([]byte, error)) Backend
 	return &backendFunc{fn: fn, name: name}
 }
 
+// Func creates a Backend from a function and allows users to add a defai;t map.
+func FuncWithDefaults(name string, defaults map[string]string, fn func(context.Context, string) ([]byte, error)) Backend {
+	return &backendFunc{fn: fn, name: name, defaults: defaults}
+}
+
 type backendFunc struct {
 	fn   func(context.Context, string) ([]byte, error)
 	name string
+	defaults map[string]string
 }
 
 func (b *backendFunc) Get(ctx context.Context, key string) ([]byte, error) {
@@ -32,4 +39,8 @@ func (b *backendFunc) Get(ctx context.Context, key string) ([]byte, error) {
 
 func (b *backendFunc) Name() string {
 	return b.name
+}
+
+func (b *backendFunc) Defaults() map[string]string {
+	return b.defaults
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,7 +14,6 @@ var (
 type Backend interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Name() string
-	Defaults() map[string]string
 }
 
 // Func creates a Backend from a function.
@@ -39,8 +38,4 @@ func (b *backendFunc) Get(ctx context.Context, key string) ([]byte, error) {
 
 func (b *backendFunc) Name() string {
 	return b.name
-}
-
-func (b *backendFunc) Defaults() map[string]string {
-	return b.defaults
 }

--- a/config_test.go
+++ b/config_test.go
@@ -29,6 +29,13 @@ func (store) Name() string {
 	return "store"
 }
 
+func (store) Defaults() map[string]string {
+	var defaults map[string]string
+
+	defaults["name"] = "name"
+	return defaults
+}
+
 type longRunningStore time.Duration
 
 func (s longRunningStore) Get(ctx context.Context, key string) ([]byte, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -29,13 +29,6 @@ func (store) Name() string {
 	return "store"
 }
 
-func (store) Defaults() map[string]string {
-	var defaults map[string]string
-
-	defaults["name"] = "name"
-	return defaults
-}
-
 type longRunningStore time.Duration
 
 func (s longRunningStore) Get(ctx context.Context, key string) ([]byte, error) {


### PR DESCRIPTION
In this pull request, we are adding a map of defaults for usage by the different backends.  Based on the ticket, I believe this is what is required, however I do apologize if I misunderstood it

I also wasn't sure if a the type `map[string][string]` is the best solution.  I was thinking of using a `map[string]interface{}`, but wasn't sure if the user would want to define an object as a value

[Issue # 12](https://github.com/heetch/confita/issues/12)