### PR TITLE
Add optional parameter for file backend

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -13,7 +13,14 @@ import (
 )
 
 // ErrOpenOptionalFile is returned when opening an optional file returns an error.
-type ErrOpenOptionalFile error
+type ErrOpenOptionalFile struct {
+	path string
+	err  error
+}
+
+func (e *ErrOpenOptionalFile) Error() string {
+	return fmt.Sprintf("failed to open optional file at path \"%s\": %s", e.path, e.err.Error())
+}
 
 // Backend that loads a configuration from a file.
 // It supports json and yaml formats.
@@ -45,7 +52,7 @@ func (b *Backend) Unmarshal(ctx context.Context, to interface{}) error {
 	f, err := os.Open(b.path)
 	if err != nil {
 		if b.optional {
-			return ErrOpenOptionalFile(fmt.Errorf("failed to open optional file at path \"%s\": %s", b.path, err.Error()))
+			return &ErrOpenOptionalFile{path: b.path, err: err}
 		}
 		return errors.Wrapf(err, "failed to open file at path \"%s\"", b.path)
 	}

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ErrOpenOptionalFile is returned when opening an optional file returns an error.
 type ErrOpenOptionalFile error
 
 // Backend that loads a configuration from a file.

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type ErrOpenOptionalFile error
+
 // Backend that loads a configuration from a file.
 // It supports json and yaml formats.
 type Backend struct {
@@ -42,8 +44,7 @@ func (b *Backend) Unmarshal(ctx context.Context, to interface{}) error {
 	f, err := os.Open(b.path)
 	if err != nil {
 		if b.optional {
-			fmt.Printf("failed to open file at path \"%s\": %s\n", b.path, err.Error())
-			return nil
+			return ErrOpenOptionalFile(fmt.Errorf("failed to open optional file at path \"%s\": %s", b.path, err.Error()))
 		}
 		return errors.Wrapf(err, "failed to open file at path \"%s\"", b.path)
 	}

--- a/backend/file/file_test.go
+++ b/backend/file/file_test.go
@@ -41,7 +41,7 @@ func TestFileBackend(t *testing.T) {
 
 	testLoad := func(t *testing.T, path string) {
 		var c config
-		b := file.NewBackend(path)
+		b := file.NewBackend(path, false)
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.NoError(t, err)
@@ -90,17 +90,25 @@ timeout = 10
 		defer cleanup()
 
 		var c config
-		b := file.NewBackend(path)
+		b := file.NewBackend(path, false)
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.Error(t, err)
 	})
 
-	t.Run("File not found", func(t *testing.T) {
+	t.Run("Required file not found", func(t *testing.T) {
 		var c config
-		b := file.NewBackend("some path")
+		b := file.NewBackend("some path", false)
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.Error(t, err)
+	})
+
+	t.Run("Optional file not found", func(t *testing.T) {
+		var c config
+		b := file.NewBackend("some path", true)
+
+		err := b.Unmarshal(context.Background(), &c)
+		require.NoError(t, err)
 	})
 }

--- a/backend/file/file_test.go
+++ b/backend/file/file_test.go
@@ -110,7 +110,7 @@ timeout = 10
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.Error(t, err)
-		_, ok := err.(file.ErrOpenOptionalFile)
+		_, ok := err.(*file.ErrOpenOptionalFile)
 		require.True(t, ok)
 	})
 }

--- a/backend/file/file_test.go
+++ b/backend/file/file_test.go
@@ -109,6 +109,8 @@ timeout = 10
 		b := file.NewBackend("some path", true)
 
 		err := b.Unmarshal(context.Background(), &c)
-		require.NoError(t, err)
+		require.Error(t, err)
+		_, ok := err.(file.ErrOpenOptionalFile)
+		require.True(t, ok)
 	})
 }

--- a/backend/file/file_test.go
+++ b/backend/file/file_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heetch/confita/backend"
 	"github.com/heetch/confita/backend/file"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestFileBackend(t *testing.T) {
 
 	testLoad := func(t *testing.T, path string) {
 		var c config
-		b := file.NewBackend(path, false)
+		b := file.NewBackend(path)
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.NoError(t, err)
@@ -90,7 +91,7 @@ timeout = 10
 		defer cleanup()
 
 		var c config
-		b := file.NewBackend(path, false)
+		b := file.NewBackend(path)
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.Error(t, err)
@@ -98,7 +99,7 @@ timeout = 10
 
 	t.Run("Required file not found", func(t *testing.T) {
 		var c config
-		b := file.NewBackend("some path", false)
+		b := file.NewBackend("some path")
 
 		err := b.Unmarshal(context.Background(), &c)
 		require.Error(t, err)
@@ -106,11 +107,9 @@ timeout = 10
 
 	t.Run("Optional file not found", func(t *testing.T) {
 		var c config
-		b := file.NewBackend("some path", true)
+		b := file.NewOptionalBackend("some path")
 
 		err := b.Unmarshal(context.Background(), &c)
-		require.Error(t, err)
-		_, ok := err.(*file.ErrOpenOptionalFile)
-		require.True(t, ok)
+		require.EqualError(t, err, backend.ErrNotFound.Error())
 	})
 }

--- a/config.go
+++ b/config.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -24,8 +21,6 @@ type Loader struct {
 	// configuration keys and options.
 	// If empty, "config" is used.
 	Tag string
-
-	log *log.Logger
 }
 
 // Unmarshaler can be implemented by backends to receive the struct directly and load values into it.
@@ -42,7 +37,6 @@ type StructLoader interface {
 func NewLoader(backends ...backend.Backend) *Loader {
 	l := Loader{
 		backends: backends,
-		log:      log.New(ioutil.Discard, "[confita] ", log.LstdFlags),
 	}
 
 	if len(l.backends) == 0 {
@@ -50,12 +44,6 @@ func NewLoader(backends ...backend.Backend) *Loader {
 	}
 
 	return &l
-}
-
-// SetLoggerOutput is used for setting a writter for Confita's logger.
-// By default, it logs to ioutil.Discard.
-func (l *Loader) SetLoggerOutput(w io.Writer) {
-	l.log.SetOutput(w)
 }
 
 // Load analyses all the Fields of the given struct for a "config" tag and queries each backend

--- a/config.go
+++ b/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/heetch/confita/backend"
 	"github.com/heetch/confita/backend/env"
-	"github.com/heetch/confita/backend/file"
 )
 
 // Loader loads configuration keys from backends and stores them is a struct.
@@ -185,8 +184,7 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 		if u, ok := b.(Unmarshaler); ok {
 			err := u.Unmarshal(ctx, s.S)
 			if err != nil {
-				if uerr, ok := err.(*file.ErrOpenOptionalFile); ok {
-					l.log.Println(uerr.Error())
+				if err == backend.ErrNotFound {
 					continue
 				}
 				return err
@@ -218,7 +216,6 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 				if err == backend.ErrNotFound {
 					continue
 				}
-
 				return err
 			}
 

--- a/config.go
+++ b/config.go
@@ -185,7 +185,7 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 		if u, ok := b.(Unmarshaler); ok {
 			err := u.Unmarshal(ctx, s.S)
 			if err != nil {
-				if uerr, ok := err.(file.ErrOpenOptionalFile); ok {
+				if uerr, ok := err.(*file.ErrOpenOptionalFile); ok {
 					l.log.Println(uerr.Error())
 					continue
 				}

--- a/go.sum
+++ b/go.sum
@@ -163,7 +163,6 @@ github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG67
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.1 h1:mYs6SMzu72+90OcPa5wr3nfznA4Dw9UyR791ZFNOIf4=
 github.com/hashicorp/serf v0.8.1/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/vault v0.9.6 h1:AalVi4vunOMSXX7eD8j8WKxkWr2AmG6yvz9o3ITSaMc=
 github.com/hashicorp/vault v0.9.6/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,7 @@ github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG67
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.1 h1:mYs6SMzu72+90OcPa5wr3nfznA4Dw9UyR791ZFNOIf4=
 github.com/hashicorp/serf v0.8.1/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
+github.com/hashicorp/vault v0.9.6 h1:AalVi4vunOMSXX7eD8j8WKxkWr2AmG6yvz9o3ITSaMc=
 github.com/hashicorp/vault v0.9.6/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
Sometimes the configuration file is not required and Confita shouldn't fail in this case.

Fix #55.