### PR TITLE
set value only from first successful backend

### DIFF
--- a/config.go
+++ b/config.go
@@ -160,6 +160,8 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 		}
 	}
 
+	foundFields := make(map[*FieldConfig]bool)
+
 	for _, b := range l.backends {
 		select {
 		case <-ctx.Done():
@@ -186,6 +188,10 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 		}
 
 		for _, f := range s.Fields {
+			if _, ok := foundFields[f]; ok {
+				continue
+			}
+
 			if f.Backend != "" && f.Backend != b.Name() {
 				continue
 			}
@@ -203,6 +209,7 @@ func (l *Loader) resolve(ctx context.Context, s *StructConfig) error {
 			if err != nil {
 				return err
 			}
+			foundFields[f] = true
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -188,6 +188,23 @@ func TestLoadIgnored(t *testing.T) {
 	require.Zero(t, s.Name)
 }
 
+func TestLoadFirstBackendWins(t *testing.T) {
+	s := struct {
+		Age  int    `config:"age"`
+	}{}
+
+	st1 := store{
+		"age":  "10",
+	}
+	st2 := store {
+		"age": "77",
+	}
+
+	err := confita.NewLoader(st1, st2).Load(context.Background(), &s)
+	require.NoError(t, err)
+	require.Equal(t, 10, s.Age)
+}
+
 func TestLoadContextCancel(t *testing.T) {
 	s := struct {
 		Name string `config:"-"`


### PR DESCRIPTION
Fixes #64.

As called out in the issue, docs say:

> Confita scans a struct for config tags and calls all the backends one after another until the key is found

But, the code is currently iterating through each field and backend, overwriting any last values that were previously set.