### PR TITLE
backend/env: treat empty environment variables as not found

### DIFF
--- a/backend/env/env.go
+++ b/backend/env/env.go
@@ -13,18 +13,13 @@ import (
 // lowercase letters to uppercase.
 func NewBackend() backend.Backend {
 	return backend.Func("env", func(ctx context.Context, key string) ([]byte, error) {
-		val, ok := os.LookupEnv(key)
-		if ok {
+		if val := os.Getenv(key); val != "" {
 			return []byte(val), nil
 		}
-
 		key = strings.Replace(strings.ToUpper(key), "-", "_", -1)
-
-		val, ok = os.LookupEnv(key)
-		if ok {
+		if val := os.Getenv(key); val != "" {
 			return []byte(val), nil
 		}
-
 		return nil, backend.ErrNotFound
 	})
 }

--- a/backend/env/env_test.go
+++ b/backend/env/env_test.go
@@ -10,10 +10,18 @@ import (
 )
 
 func TestEnvBackend(t *testing.T) {
-	t.Run("NotFound", func(t *testing.T) {
+	t.Run("NotFoundBecauseUnset", func(t *testing.T) {
 		b := NewBackend()
 
 		_, err := b.Get(context.Background(), "something that doesn't exist")
+		require.Equal(t, backend.ErrNotFound, err)
+
+	})
+
+	t.Run("NotFoundBecauseEmpty", func(t *testing.T) {
+		b := NewBackend()
+		os.Setenv("TESTCONFIG", "")
+		_, err := b.Get(context.Background(), "TESTCONFIG")
 		require.Equal(t, backend.ErrNotFound, err)
 	})
 


### PR DESCRIPTION
It's very unusual to distinguish between an environment variable
that's unset and one that's empty. When a value is required, looking
for a non-empty environment variable feels more correct.

As a recent example, the kafka-go config contained a "required" entry
for `KAFKA_ADDRS` which was satisfied by an empty environment
variable.