### PR TITLE
Add support for Vault KV secrets engine v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ before_script:
   - docker run -d -p 2379:2379 quay.io/coreos/etcd /usr/local/bin/etcd -advertise-client-urls http://0.0.0.0:2379 -listen-client-urls http://0.0.0.0:2379
   - docker run -d -p 8500:8500 --name consul consul
   - docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault:0.9.6
+  - docker run -d -p 8222:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=root' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' vault:0.10.0

--- a/backend/vault/vault.go
+++ b/backend/vault/vault.go
@@ -39,8 +39,16 @@ func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 	}
 
-	if v, ok := b.secret.Data[key]; ok {
-		return []byte(v.(string)), nil
+	data, ok := b.secret.Data["data"]
+	if ok {
+		data := data.(map[string]interface{})
+		if v, ok := data[key]; ok {
+			return []byte(v.(string)), nil
+		}
+	} else {
+		if v, ok := b.secret.Data[key]; ok {
+			return []byte(v.(string)), nil
+		}
 	}
 
 	return nil, backend.ErrNotFound

--- a/backend/vault/vault.go
+++ b/backend/vault/vault.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/vault/api"
 
@@ -32,6 +33,12 @@ func NewBackend(client *api.Logical, path string) *Backend {
 // all the keys from the given path and holds them in memory.
 // Use this when using Vault KV secrets engine v2.
 func NewBackendV2(client *api.Logical, path string) *Backend {
+	path = strings.TrimPrefix(path, "/")
+	// The KV secrets engine v2 uses the "secrets/data" prefix in the path,
+	// but we want to support regular paths as well, just like the Vault CLI does.
+	if strings.HasPrefix(path, "secret/") && !strings.HasPrefix(path, "secret/data/") {
+		path = "secret/data/" + strings.TrimPrefix(path, "secret/")
+	}
 	return &Backend{
 		client: client,
 		path:   path,

--- a/backend/vault/vault.go
+++ b/backend/vault/vault.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/api"
+
 	"github.com/heetch/confita/backend"
 )
 
@@ -13,14 +14,28 @@ type Backend struct {
 	client *api.Logical
 	path   string
 	secret *api.Secret
+	// KV secrets engine v2
+	v2 bool
 }
 
 // NewBackend creates a configuration loader that loads from Vault
 // all the keys from the given path and holds them in memory.
+// Use this when using Vault KV secrets engine v1.
 func NewBackend(client *api.Logical, path string) *Backend {
 	return &Backend{
 		client: client,
 		path:   path,
+	}
+}
+
+// NewBackendV2 creates a configuration loader that loads from Vault
+// all the keys from the given path and holds them in memory.
+// Use this when using Vault KV secrets engine v2.
+func NewBackendV2(client *api.Logical, path string) *Backend {
+	return &Backend{
+		client: client,
+		path:   path,
+		v2:     true,
 	}
 }
 
@@ -39,11 +54,12 @@ func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 	}
 
-	data, ok := b.secret.Data["data"]
-	if ok {
-		data := data.(map[string]interface{})
-		if v, ok := data[key]; ok {
-			return []byte(v.(string)), nil
+	if b.v2 {
+		if data, ok := b.secret.Data["data"]; ok {
+			data := data.(map[string]interface{})
+			if v, ok := data[key]; ok {
+				return []byte(v.(string)), nil
+			}
 		}
 	} else {
 		if v, ok := b.secret.Data[key]; ok {

--- a/backend/vault/vault.go
+++ b/backend/vault/vault.go
@@ -37,7 +37,7 @@ func NewBackendV2(client *api.Logical, path string) *Backend {
 	// The KV secrets engine v2 uses the "secrets/data" prefix in the path,
 	// but we want to support regular paths as well, just like the Vault CLI does.
 	if strings.HasPrefix(path, "secret/") && !strings.HasPrefix(path, "secret/data/") {
-		path = "secret/data/" + strings.TrimPrefix(path, "secret/")
+		path = strings.Replace(path, "secret/", "secret/data/", 1)
 	}
 	return &Backend{
 		client: client,

--- a/backend/vault/vault_test.go
+++ b/backend/vault/vault_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/heetch/confita/backend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/heetch/confita/backend"
 )
 
 func TestVaultBackend(t *testing.T) {
@@ -34,8 +35,54 @@ func TestVaultBackend(t *testing.T) {
 
 		_, err = c.Write(path,
 			map[string]interface{}{
-				"foo":    "bar",
-				"cheese": "nan",
+				"foo":  "bar",
+				"data": "nan",
+			})
+		require.NoError(t, err)
+
+		val, err := b.Get(context.Background(), "foo")
+		require.NoError(t, err)
+		assert.Equal(t, "bar", string(val))
+
+		val, err = b.Get(context.Background(), "data")
+		require.NoError(t, err)
+		assert.Equal(t, "nan", string(val))
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		b := NewBackend(c, path)
+		_, err := b.Get(context.Background(), "badKey")
+		require.EqualError(t, err, backend.ErrNotFound.Error())
+	})
+}
+
+func TestVaultBackendV2(t *testing.T) {
+	os.Setenv("VAULT_ADDR", "http://127.0.0.1:8222")
+	client, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+
+	client.SetToken("root")
+	c := client.Logical()
+
+	path := "secret/data/test"
+
+	defer c.Delete(path)
+
+	t.Run("SecretPathNotFound", func(t *testing.T) {
+		b := NewBackendV2(c, path)
+		_, err := b.Get(context.Background(), "foo")
+		require.EqualError(t, err, "secret not found at the following path: secret/data/test")
+	})
+
+	t.Run("OK", func(t *testing.T) {
+		b := NewBackendV2(c, path)
+
+		_, err = c.Write(path,
+			map[string]interface{}{
+				"data": map[string]string{
+					"foo":    "bar",
+					"cheese": "nan",
+				},
 			})
 		require.NoError(t, err)
 
@@ -49,7 +96,7 @@ func TestVaultBackend(t *testing.T) {
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
-		b := NewBackend(c, path)
+		b := NewBackendV2(c, path)
 		_, err := b.Get(context.Background(), "badKey")
 		require.EqualError(t, err, backend.ErrNotFound.Error())
 	})


### PR DESCRIPTION
This PR builds on top of https://github.com/heetch/confita/pull/84 (thanks @mopemope!), but completely separates the handling of Vault KV secret engine v1 and v2 to ensure that no breaking changes are introduced for v1 users, for example when asking for the secret with key "data".

This PR also
-  adds a test for the v2 backend, also adding a newer Vault version in CI (not the newest one, only the oldest one that leads to our Vault backend v1 implementation not working anymore)
- changes the tests to use "data" as key to make sure no handling of "data" in the implementation breaks that

ℹ️ In the future it could be nice to have both secret engines handled by one backend, but it might require a bit more work, similar to what the Vault CLI does here: https://github.com/hashicorp/vault/blob/28fc7714655b34d700150f8f81589013d6a07e55/command/kv_get.go#L94-L147

Background info:
- Secrets engine v1 API: https://www.vaultproject.io/api-docs/secret/kv/kv-v1#read-secret
- Secrets engine v2 API: https://www.vaultproject.io/api-docs/secret/kv/kv-v2#read-secret-version
- v0.10.0 release notes mentioning the "complete backend revamp" and introduction of versioned KV: https://github.com/hashicorp/vault/blob/00dfb97d67bd9eac5661b0ec62695b2c19e166cf/CHANGELOG.md#0100-april-10th-2018