### PR TITLE
pin etcd version in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
           ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
       consul:
-        image: consul
+        image: hashicorp/consul
         ports:
           - 8500:8500
       vault096:


### PR DESCRIPTION
fixing CI by:
* pinning the etcd version in the CI (The latest tag has been [removed](https://github.com/etcd-io/etcd/issues/15382) from the repo)
* changing the consul image