### PR TITLE
Add support for non-pointer `time.Time`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ type Config struct {
   Host        string        `config:"host"`
   Port        uint32        `config:"port"`
   Timeout     time.Duration `config:"timeout"`
-  SomeVal     *time.Time    `config:"someval"`
+  SomeVal     time.Time     `config:"someval"`
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -57,7 +57,7 @@ func (l *Loader) Load(ctx context.Context, to any) error {
 
 	ref := reflect.ValueOf(to)
 
-	if !ref.IsValid() || ref.Kind() != reflect.Ptr || ref.Elem().Kind() != reflect.Struct {
+	if !ref.IsValid() || ref.Kind() != reflect.Pointer || ref.Elem().Kind() != reflect.Struct {
 		return errors.New("provided target must be a pointer to struct")
 	}
 
@@ -103,7 +103,7 @@ func (l *Loader) parseStruct(ref reflect.Value) *StructConfig {
 			}
 			s.Fields = append(s.Fields, l.parseStruct(value).Fields...)
 			continue
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if typ.Elem().Kind() == reflect.Struct && !value.IsNil() {
 				s.Fields = append(s.Fields, l.parseStruct(value.Elem()).Fields...)
 				continue
@@ -314,7 +314,7 @@ func convert(data string, value reflect.Value) error {
 		return err
 	case reflect.String:
 		value.SetString(data)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		n := reflect.New(value.Type().Elem())
 		value.Set(n)
 		return convert(data, n.Elem())

--- a/config.go
+++ b/config.go
@@ -97,6 +97,10 @@ func (l *Loader) parseStruct(ref reflect.Value) *StructConfig {
 		// if struct or *struct, parse recursively
 		switch typ.Kind() {
 		case reflect.Struct:
+			// Exception for `time.Time` struct
+			if typ == timeType {
+				break
+			}
 			s.Fields = append(s.Fields, l.parseStruct(value).Fields...)
 			continue
 		case reflect.Ptr:

--- a/config_test.go
+++ b/config_test.go
@@ -66,23 +66,25 @@ func TestLoad(t *testing.T) {
 	}
 
 	type testStruct struct {
-		Bool            bool          `config:"bool"`
-		Int             int           `config:"int"`
-		Int8            int8          `config:"int8"`
-		Int16           int16         `config:"int16"`
-		Int32           int32         `config:"int32"`
-		Int64           int64         `config:"int64"`
-		Uint            uint          `config:"uint"`
-		Uint8           uint8         `config:"uint8"`
-		Uint16          uint16        `config:"uint16"`
-		Uint32          uint32        `config:"uint32"`
-		Uint64          uint64        `config:"uint64"`
-		Float32         float32       `config:"float32"`
-		Float64         float64       `config:"float64"`
-		Ptr             *string       `config:"ptr"`
-		String          string        `config:"string"`
-		Duration        time.Duration `config:"duration"`
-		Time            *time.Time    `config:"time"`
+		Bool            bool           `config:"bool"`
+		Int             int            `config:"int"`
+		Int8            int8           `config:"int8"`
+		Int16           int16          `config:"int16"`
+		Int32           int32          `config:"int32"`
+		Int64           int64          `config:"int64"`
+		Uint            uint           `config:"uint"`
+		Uint8           uint8          `config:"uint8"`
+		Uint16          uint16         `config:"uint16"`
+		Uint32          uint32         `config:"uint32"`
+		Uint64          uint64         `config:"uint64"`
+		Float32         float32        `config:"float32"`
+		Float64         float64        `config:"float64"`
+		Ptr             *string        `config:"ptr"`
+		String          string         `config:"string"`
+		Duration        time.Duration  `config:"duration"`
+		DurationPtr     *time.Duration `config:"duration"`
+		Time            time.Time      `config:"time"`
+		TimePtr         *time.Time     `config:"time"`
 		Struct          nested
 		StructPtrNil    *nested
 		StructPtrNotNil *nested
@@ -118,11 +120,12 @@ func TestLoad(t *testing.T) {
 		"float64": strconv.FormatFloat(math.MaxFloat64, 'f', 6, 64),
 	}
 
+	duration := 10 * time.Second
 	date := time.Now().UTC().Truncate(time.Second)
 	otherStore := store{
 		"ptr":      "ptr",
 		"string":   "string",
-		"duration": "10s",
+		"duration": duration.String(),
 		"time":     date.Format(time.RFC3339),
 	}
 
@@ -137,23 +140,25 @@ func TestLoad(t *testing.T) {
 
 	ptr := "ptr"
 	require.EqualValues(t, testStruct{
-		Bool:     true,
-		Int:      math.MaxInt64,
-		Int8:     math.MaxInt8,
-		Int16:    math.MaxInt16,
-		Int32:    math.MaxInt32,
-		Int64:    math.MaxInt64,
-		Uint:     math.MaxUint64,
-		Uint8:    math.MaxUint8,
-		Uint16:   math.MaxUint16,
-		Uint32:   math.MaxUint32,
-		Uint64:   math.MaxUint64,
-		Float32:  math.MaxFloat32,
-		Float64:  math.MaxFloat64,
-		Ptr:      &ptr,
-		String:   "string",
-		Duration: 10 * time.Second,
-		Time:     &date,
+		Bool:        true,
+		Int:         math.MaxInt64,
+		Int8:        math.MaxInt8,
+		Int16:       math.MaxInt16,
+		Int32:       math.MaxInt32,
+		Int64:       math.MaxInt64,
+		Uint:        math.MaxUint64,
+		Uint8:       math.MaxUint8,
+		Uint16:      math.MaxUint16,
+		Uint32:      math.MaxUint32,
+		Uint64:      math.MaxUint64,
+		Float32:     math.MaxFloat32,
+		Float64:     math.MaxFloat64,
+		Ptr:         &ptr,
+		String:      "string",
+		Duration:    duration,
+		DurationPtr: &duration,
+		Time:        date,
+		TimePtr:     &date,
 		Struct: nested{
 			Int:    math.MaxInt64,
 			String: "string",
@@ -462,7 +467,6 @@ func TestSliceField(t *testing.T) {
 	})
 
 	t.Run("Slice of string - non-empty - no appending", func(t *testing.T) {
-
 		s := struct {
 			Letters []string `config:"letters"`
 		}{


### PR DESCRIPTION
https://github.com/heetch/confita/pull/99 added support for `*time.Time`, but not for `time.Time`.

This PR adds that.

We still don't have time support in `flags.go`, which we should add as well. But we can do that in [another PR](https://github.com/heetch/confita/pull/101).