### PR TITLE
feat: use goccy/go-yaml as YAML decoder

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -7,13 +7,14 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/heetch/confita/backend"
+	yaml "github.com/goccy/go-yaml"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+
+	"github.com/heetch/confita/backend"
 )
 
 // Backend that loads a configuration from a file.
-// It supports json and yaml formats.
+// It supports JSON, YAML, and TOML formats.
 type Backend struct {
 	path     string
 	name     string
@@ -51,8 +52,8 @@ func NewOptionalBackend(path string) *Backend {
 }
 
 // Unmarshal takes a struct pointer and unmarshals the file into it,
-// using either json or yaml based on the file extention.
-func (b *Backend) Unmarshal(ctx context.Context, to any) error {
+// using JSON, YAML, or TOML depending on the file extension.
+func (b *Backend) Unmarshal(_ context.Context, to any) error {
 	f, err := os.Open(b.path)
 	if err != nil {
 		if b.optional {
@@ -79,7 +80,7 @@ func (b *Backend) Unmarshal(ctx context.Context, to any) error {
 }
 
 // Get is not implemented.
-func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
+func (b *Backend) Get(_ context.Context, _ string) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/aws/aws-sdk-go v1.23.20
 	github.com/coreos/etcd v3.3.3+incompatible
+	github.com/goccy/go-yaml v1.19.0
 	github.com/hashicorp/consul/api v1.1.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
-	gopkg.in/yaml.v2 v2.2.2
 )
 
 require (
@@ -64,6 +64,7 @@ require (
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
 go 1.23.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/goccy/go-yaml v1.19.0 h1:EmkZ9RIsX+Uq4DYFowegAuJo8+xdX3T/2dwNPXbxEYE=
+github.com/goccy/go-yaml v1.19.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
This PR replaces the archived [go-yaml](https://github.com/go-yaml/yaml) package with a newer, actively maintained alternative. 

This package introduces some breaking changes in YAML parsing that may cause Confita to behave differently. 

For example, `gopkg.in/yaml.v2` [parses](https://go.dev/play/p/cnO8DuWRcmi) the string value `yes` as a boolean `true`, whereas `goccy/go-yaml` treats it as a string. 

Due to these changes, a major version bump will be required.